### PR TITLE
Add business context configuration and calendar scheduling

### DIFF
--- a/base-baileys-memory/.env.example
+++ b/base-baileys-memory/.env.example
@@ -1,0 +1,14 @@
+# Gemini configuration
+GEMINI_API_KEY=your_gemini_api_key_here
+# GEMINI_MODEL=gemini-1.5-pro
+
+# Scheduling defaults
+DEFAULT_TIMEZONE=America/Mexico_City
+DEFAULT_APPOINTMENT_DURATION_MINUTES=45
+
+# Google Calendar OAuth 2.0
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_REFRESH_TOKEN=your_google_refresh_token
+GOOGLE_CALENDAR_ID=your_calendar_id@group.calendar.google.com
+# GOOGLE_REDIRECT_URI=https://developers.google.com/oauthplayground

--- a/base-baileys-memory/README.md
+++ b/base-baileys-memory/README.md
@@ -14,6 +14,19 @@ cp .env.example .env # edita el archivo y coloca tu GEMINI_API_KEY
 npm start
 ```
 
+### Personalizar el contexto del asistente
+
+- Edita `services/context.js` para actualizar la descripción del negocio, horarios, enlaces y frases clave que activan el flujo de agenda.
+- El archivo exporta `contextMessages`, que se envía como contexto base a Gemini en cada respuesta.
+
+### Configurar la agenda con Google Calendar
+
+1. Crea o reutiliza un proyecto en Google Cloud y habilita la **Google Calendar API**.
+2. Configura una credencial de **OAuth 2.0** para aplicaciones externas y genera un token de actualización con el alcance `https://www.googleapis.com/auth/calendar.events`.
+3. Copia las variables necesarias (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REFRESH_TOKEN`, `GOOGLE_CALENDAR_ID`, etc.) en tu `.env`.
+4. Ajusta el huso horario y la duración por defecto de la cita en `.env` mediante `DEFAULT_TIMEZONE` y `DEFAULT_APPOINTMENT_DURATION_MINUTES`.
+5. Una vez configurado, los usuarios pueden escribir "Agendar cita" o "Reservar cita" para iniciar el flujo automatizado que solicitará datos y registrará la cita en tu calendario.
+
 ### Configurar Gemini
 
 1. Copia el archivo `.env.example` a `.env` y agrega tu clave real de Gemini en `GEMINI_API_KEY`.

--- a/base-baileys-memory/services/calendar.js
+++ b/base-baileys-memory/services/calendar.js
@@ -1,0 +1,105 @@
+const REQUIRED_ENV_VARS = [
+    'GOOGLE_CLIENT_ID',
+    'GOOGLE_CLIENT_SECRET',
+    'GOOGLE_REFRESH_TOKEN',
+    'GOOGLE_CALENDAR_ID',
+]
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token'
+const CALENDAR_BASE_URL = 'https://www.googleapis.com/calendar/v3'
+
+const isCalendarConfigured = () => REQUIRED_ENV_VARS.every((key) => Boolean(process.env[key]))
+
+const buildTokenPayload = () => {
+    const params = new URLSearchParams()
+    params.append('client_id', process.env.GOOGLE_CLIENT_ID)
+    params.append('client_secret', process.env.GOOGLE_CLIENT_SECRET)
+    params.append('refresh_token', process.env.GOOGLE_REFRESH_TOKEN)
+    params.append('grant_type', 'refresh_token')
+    return params
+}
+
+const fetchAccessToken = async () => {
+    if (!isCalendarConfigured()) {
+        throw new Error('GOOGLE_CALENDAR_MISSING_CONFIG')
+    }
+
+    const response = await fetch(TOKEN_URL, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: buildTokenPayload(),
+    })
+
+    if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}))
+        const error = new Error(
+            errorBody?.error_description || errorBody?.error || 'GOOGLE_CALENDAR_TOKEN_ERROR'
+        )
+        error.code = response.status
+        throw error
+    }
+
+    const json = await response.json()
+    if (!json.access_token) {
+        const error = new Error('GOOGLE_CALENDAR_TOKEN_ERROR')
+        error.code = 'TOKEN_MISSING'
+        throw error
+    }
+
+    return json.access_token
+}
+
+const createCalendarEvent = async ({
+    summary,
+    description,
+    startDateTime,
+    endDateTime,
+    timeZone,
+    attendees = [],
+}) => {
+    const accessToken = await fetchAccessToken()
+    const calendarId = process.env.GOOGLE_CALENDAR_ID
+
+    const response = await fetch(
+        `${CALENDAR_BASE_URL}/calendars/${encodeURIComponent(calendarId)}/events`,
+        {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                summary,
+                description,
+                start: {
+                    dateTime: startDateTime,
+                    timeZone,
+                },
+                end: {
+                    dateTime: endDateTime,
+                    timeZone,
+                },
+                attendees,
+            }),
+        }
+    )
+
+    if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({}))
+        const errorMessage =
+            errorBody?.error?.message || `Error HTTP ${response.status}: ${response.statusText}`
+        const error = new Error(errorMessage)
+        error.code = response.status
+        error.details = errorBody
+        throw error
+    }
+
+    return response.json()
+}
+
+module.exports = {
+    createCalendarEvent,
+    isCalendarConfigured,
+}

--- a/base-baileys-memory/services/context.js
+++ b/base-baileys-memory/services/context.js
@@ -1,0 +1,55 @@
+const businessInfo = {
+    organizationName: 'Consejo de Enfermería',
+    description:
+        'Somos el equipo especializado en homologar la carrera de enfermería para validar estudios universitarios de México en Estados Unidos.',
+    officeHours:
+        'Atendemos de lunes a viernes en horario laboral de la Ciudad de México. Actualiza este texto si tus horarios cambian.',
+    location:
+        'Brindamos asesoría 100% en línea para profesionales de enfermería que desean ejercer en Estados Unidos.',
+    schedulingKeywords: ['Agendar cita', 'Reservar cita', 'Agendar llamada'],
+    schedulingInstructions:
+        'Cuando la persona esté lista, indícale que escriba "Agendar cita" o "Reservar cita" para iniciar el proceso automatizado de agenda.',
+    contactEmail: 'Actualiza aquí tu correo de contacto si deseas compartirlo automáticamente.',
+    website: 'Añade tu sitio web o landing page oficial si deseas compartir un enlace.',
+}
+
+const buildOptionalSections = () => {
+    const optionalLines = [
+        businessInfo.officeHours && `Horarios de atención: ${businessInfo.officeHours}.`,
+        businessInfo.location && `Ubicación o modalidad: ${businessInfo.location}.`,
+        businessInfo.contactEmail && `Correo de contacto: ${businessInfo.contactEmail}.`,
+        businessInfo.website && `Sitio web: ${businessInfo.website}.`,
+        businessInfo.schedulingInstructions,
+    ].filter(Boolean)
+
+    return optionalLines.join('\n')
+}
+
+const baseContext = `Eres el asistente virtual oficial de ${businessInfo.organizationName} en WhatsApp. ${businessInfo.description}
+
+Tu objetivo es escuchar atentamente la situación de la persona, explicar de forma clara el proceso de homologación y recalcar que contará con un asesor que la guiará paso a paso hasta obtener la validación en Estados Unidos.
+
+Proporciona información práctica y confiable basada en los datos disponibles. Si falta algún detalle (como horarios exactos, direcciones o precios), aclara que un asesor lo confirmará durante la llamada de orientación.
+
+Mantén un tono cálido, profesional y motivador. Resume los pasos principales del proceso y resalta los beneficios de contar con nuestro acompañamiento personalizado.
+
+Siempre invita a agendar una llamada de orientación. Indica que pueden escribir alguna de las siguientes frases para iniciar la reserva automática: ${businessInfo.schedulingKeywords.join(', ')}.
+
+${buildOptionalSections()}`.trim()
+
+const contextMessages = [
+    {
+        role: 'user',
+        parts: [
+            {
+                text: baseContext,
+            },
+        ],
+    },
+]
+
+module.exports = {
+    baseContext,
+    businessInfo,
+    contextMessages,
+}

--- a/base-baileys-memory/services/gemini.js
+++ b/base-baileys-memory/services/gemini.js
@@ -49,13 +49,14 @@ const parseGeminiResponse = (payload) => {
     return cleanResponse(parts.join('\n'))
 }
 
-const getGeminiReply = async (message, history = []) => {
+const getGeminiReply = async (message, history = [], context = []) => {
     if (!API_KEY) {
         throw new Error('GEMINI_API_KEY_MISSING')
     }
 
     const sanitizedHistory = sanitizeHistory(history)
-    const contents = [...sanitizedHistory, buildHistoryEntry('user', message)]
+    const sanitizedContext = sanitizeHistory(context)
+    const contents = [...sanitizedContext, ...sanitizedHistory, buildHistoryEntry('user', message)]
 
     let response
     try {

--- a/base-baileys-memory/services/scheduling.js
+++ b/base-baileys-memory/services/scheduling.js
@@ -1,0 +1,415 @@
+const { businessInfo } = require('./context')
+const { createCalendarEvent, isCalendarConfigured } = require('./calendar')
+
+const DEFAULT_TIMEZONE = process.env.DEFAULT_TIMEZONE || 'America/Mexico_City'
+const DEFAULT_APPOINTMENT_DURATION_MINUTES = Number(
+    process.env.DEFAULT_APPOINTMENT_DURATION_MINUTES || 45
+)
+
+const MONTH_NAMES = [
+    'enero',
+    'febrero',
+    'marzo',
+    'abril',
+    'mayo',
+    'junio',
+    'julio',
+    'agosto',
+    'septiembre',
+    'octubre',
+    'noviembre',
+    'diciembre',
+]
+
+const padNumber = (value) => String(value).padStart(2, '0')
+
+const parseDateParts = (date) => {
+    const [year, month, day] = date.split('-').map(Number)
+    if ([year, month, day].some((value) => Number.isNaN(value))) return null
+
+    const candidate = new Date(Date.UTC(year, month - 1, day))
+    if (
+        candidate.getUTCFullYear() !== year ||
+        candidate.getUTCMonth() + 1 !== month ||
+        candidate.getUTCDate() !== day
+    ) {
+        return null
+    }
+
+    return { year, month, day }
+}
+
+const parseTimeParts = (time) => {
+    const [hour, minute] = time.split(':').map(Number)
+    if ([hour, minute].some((value) => Number.isNaN(value))) return null
+    if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null
+    return { hour, minute }
+}
+
+const buildIsoDateTime = (dateParts, timeParts) =>
+    `${dateParts.year}-${padNumber(dateParts.month)}-${padNumber(dateParts.day)}T${padNumber(
+        timeParts.hour
+    )}:${padNumber(timeParts.minute)}:00`
+
+const addMinutesToDateTime = (dateParts, timeParts, minutesToAdd) => {
+    const base = Date.UTC(
+        dateParts.year,
+        dateParts.month - 1,
+        dateParts.day,
+        timeParts.hour,
+        timeParts.minute,
+        0
+    )
+    const updated = new Date(base + minutesToAdd * 60 * 1000)
+
+    const newDateParts = {
+        year: updated.getUTCFullYear(),
+        month: updated.getUTCMonth() + 1,
+        day: updated.getUTCDate(),
+    }
+
+    const newTimeParts = {
+        hour: updated.getUTCHours(),
+        minute: updated.getUTCMinutes(),
+    }
+
+    return {
+        dateParts: newDateParts,
+        timeParts: newTimeParts,
+        iso: buildIsoDateTime(newDateParts, newTimeParts),
+    }
+}
+
+const formatDateForHumans = (dateParts) =>
+    `${dateParts.day} de ${MONTH_NAMES[dateParts.month - 1]} de ${dateParts.year}`
+
+const formatTimeForHumans = (timeParts) => `${padNumber(timeParts.hour)}:${padNumber(timeParts.minute)}`
+
+const START_KEYWORDS = [
+    /agendar\s+(una\s+)?(cita|llamada)/i,
+    /reservar\s+(una\s+)?(cita|llamada)/i,
+]
+
+const CANCEL_KEYWORDS = [/cancelar/i, /ya\s+no/i]
+
+const resetSchedulingState = async (state) => {
+    await state.update({
+        scheduling: null,
+    })
+}
+
+const startSchedulingFlow = async (ctx, { flowDynamic, state }) => {
+    if (!isCalendarConfigured()) {
+        await flowDynamic([
+            {
+                body: 'Por ahora no puedo agendar automáticamente porque falta configurar la conexión con Google Calendar. Contacta al equipo técnico para completar la configuración.',
+            },
+        ])
+        return true
+    }
+
+    await state.update({
+        scheduling: {
+            step: 'collectName',
+            data: {
+                phone: ctx.from,
+            },
+        },
+    })
+
+    await flowDynamic([
+        {
+            body: '¡Perfecto! Empecemos con tu cita. ¿Cuál es tu nombre completo?',
+        },
+    ])
+
+    return true
+}
+
+const handleCancellation = async ({ flowDynamic, state }) => {
+    await flowDynamic([
+        {
+            body: 'He cancelado el proceso de agenda. Si deseas retomarlo, solo escribe "Agendar cita" cuando quieras.',
+        },
+    ])
+    await resetSchedulingState(state)
+}
+
+const buildSummary = (name) =>
+    `${businessInfo.organizationName || 'Asesoría'} - Llamada de orientación con ${name}`
+
+const buildDescription = ({ name, email, notes, phone }) => {
+    const lines = [
+        'Cita agendada automáticamente desde WhatsApp.',
+        `Nombre: ${name}`,
+        `Correo: ${email}`,
+        `Teléfono: ${phone}`,
+    ]
+
+    if (notes) {
+        lines.push(`Notas: ${notes}`)
+    }
+
+    return lines.join('\n')
+}
+
+const finalizeScheduling = async (ctx, tools, scheduling) => {
+    const { flowDynamic, state } = tools
+    const { name, email, date, time, notes, phone, timeZone } = scheduling.data
+    const zone = timeZone || DEFAULT_TIMEZONE
+
+    const dateParts = parseDateParts(date)
+    const timeParts = parseTimeParts(time)
+
+    if (!dateParts || !timeParts) {
+        await flowDynamic([
+            {
+                body: 'No pude interpretar la fecha y hora proporcionadas. Revisa el formato (AAAA-MM-DD para la fecha y HH:MM en formato de 24 horas) e intenta nuevamente.',
+            },
+        ])
+        await state.update({
+            scheduling: {
+                ...scheduling,
+                step: 'collectDate',
+            },
+        })
+        return true
+    }
+
+    const startIso = buildIsoDateTime(dateParts, timeParts)
+    const endInfo = addMinutesToDateTime(dateParts, timeParts, DEFAULT_APPOINTMENT_DURATION_MINUTES)
+
+    try {
+        const event = await createCalendarEvent({
+            summary: buildSummary(name),
+            description: buildDescription({ name, email, notes, phone }),
+            startDateTime: startIso,
+            endDateTime: endInfo.iso,
+            timeZone: zone,
+            attendees: [
+                {
+                    email,
+                    displayName: name,
+                },
+            ],
+        })
+
+        await flowDynamic([
+            {
+                body: `¡Listo! Tu cita quedó agendada para el ${formatDateForHumans(
+                    dateParts
+                )} a las ${formatTimeForHumans(timeParts)} (${zone}). Te enviaremos la confirmación al correo ${email}. ${
+                    event.htmlLink ? `Puedes revisar el detalle aquí: ${event.htmlLink}` : ''
+                }`,
+            },
+        ])
+    } catch (error) {
+        console.error('Error al crear evento en Google Calendar:', error)
+
+        if (error.message === 'GOOGLE_CALENDAR_MISSING_CONFIG') {
+            await flowDynamic([
+                {
+                    body: 'No logré conectar con Google Calendar porque la configuración está incompleta. Por favor, solicita al equipo técnico completar las variables de entorno necesarias y vuelve a intentarlo.',
+                },
+            ])
+        } else {
+            await flowDynamic([
+                {
+                    body: 'Ocurrió un inconveniente al crear la cita. Notificaré al equipo para que continúe el proceso contigo manualmente.',
+                },
+            ])
+        }
+    }
+
+    await resetSchedulingState(state)
+
+    return true
+}
+
+const continueSchedulingFlow = async (ctx, tools, scheduling) => {
+    const { flowDynamic, state } = tools
+    const message = ctx.body.trim()
+
+    if (CANCEL_KEYWORDS.some((regex) => regex.test(message))) {
+        await handleCancellation(tools)
+        return true
+    }
+
+    switch (scheduling.step) {
+        case 'collectName': {
+            await state.update({
+                scheduling: {
+                    step: 'collectEmail',
+                    data: {
+                        ...scheduling.data,
+                        name: message,
+                    },
+                },
+            })
+
+            await flowDynamic([
+                {
+                    body: 'Gracias. ¿Cuál es tu correo electrónico para enviarte la confirmación?',
+                },
+            ])
+
+            return true
+        }
+        case 'collectEmail': {
+            const email = message.toLowerCase()
+            const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+            if (!emailRegex.test(email)) {
+                await flowDynamic([
+                    {
+                        body: 'Parece que el correo no es válido. Intenta nuevamente con un formato como nombre@dominio.com.',
+                    },
+                ])
+                return true
+            }
+
+            await state.update({
+                scheduling: {
+                    step: 'collectDate',
+                    data: {
+                        ...scheduling.data,
+                        email,
+                    },
+                },
+            })
+
+            await flowDynamic([
+                {
+                    body: 'Perfecto. ¿Para qué fecha necesitas la llamada? Escríbela en formato AAAA-MM-DD.',
+                },
+            ])
+
+            return true
+        }
+        case 'collectDate': {
+            const date = message
+            const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+
+            if (!dateRegex.test(date)) {
+                await flowDynamic([
+                    {
+                        body: 'Para registrar la fecha necesito el formato AAAA-MM-DD. Por ejemplo: 2024-05-15.',
+                    },
+                ])
+                return true
+            }
+
+            await state.update({
+                scheduling: {
+                    step: 'collectTime',
+                    data: {
+                        ...scheduling.data,
+                        date,
+                    },
+                },
+            })
+
+            await flowDynamic([
+                {
+                    body: `¿A qué hora te viene mejor? Indícala en formato 24 horas HH:MM (por ejemplo, 15:30). Si necesitas otra zona horaria distinta a ${DEFAULT_TIMEZONE}, menciónalo aquí.`,
+                },
+            ])
+
+            return true
+        }
+        case 'collectTime': {
+            const timeMatch = message.match(/\b(\d{2}:\d{2})\b/)
+            const timezoneMatch = message.match(/GMT[+-]\d{1,2}|UTC[+-]\d{1,2}|[A-Za-z]+\/[A-Za-z_]+/)
+
+            if (!timeMatch) {
+                await flowDynamic([
+                    {
+                        body: 'Necesito la hora en formato 24 horas HH:MM. Por ejemplo, 09:00 o 16:45.',
+                    },
+                ])
+                return true
+            }
+
+            const time = timeMatch[1]
+            let timeZone = DEFAULT_TIMEZONE
+            if (timezoneMatch) {
+                const rawZone = timezoneMatch[0]
+                if (/^GMT[+-]\d{1,2}$/i.test(rawZone)) {
+                    timeZone = rawZone.replace(/^GMT/i, 'UTC')
+                } else if (/^UTC[+-]\d{1,2}$/i.test(rawZone)) {
+                    timeZone = rawZone.toUpperCase()
+                } else {
+                    timeZone = rawZone
+                }
+            }
+
+            await state.update({
+                scheduling: {
+                    step: 'collectNotes',
+                    data: {
+                        ...scheduling.data,
+                        time,
+                        timeZone,
+                    },
+                },
+            })
+
+            await flowDynamic([
+                {
+                    body: '¿Hay algo adicional que debamos tener en cuenta para la llamada? Puedes escribir "No" si no es necesario.',
+                },
+            ])
+
+            return true
+        }
+        case 'collectNotes': {
+            const notes = /^(no|ninguno|ninguna)$/i.test(message) ? '' : message
+
+            await state.update({
+                scheduling: {
+                    ...scheduling,
+                    step: 'finalize',
+                    data: {
+                        ...scheduling.data,
+                        notes,
+                    },
+                },
+            })
+
+            return finalizeScheduling(ctx, tools, {
+                ...scheduling,
+                data: {
+                    ...scheduling.data,
+                    notes,
+                },
+            })
+        }
+        default:
+            await resetSchedulingState(state)
+            return false
+    }
+}
+
+const handleSchedulingFlow = async (ctx, tools) => {
+    const message = ctx?.body?.trim()
+    if (!message) return false
+
+    const userState = (typeof tools.state.getMyState === 'function'
+        ? tools.state.getMyState()
+        : tools.state) || {}
+    const scheduling = userState.scheduling
+
+    if (scheduling?.step) {
+        return continueSchedulingFlow(ctx, tools, scheduling)
+    }
+
+    if (START_KEYWORDS.some((regex) => regex.test(message))) {
+        return startSchedulingFlow(ctx, tools)
+    }
+
+    return false
+}
+
+module.exports = {
+    handleSchedulingFlow,
+}


### PR DESCRIPTION
## Summary
- add a configurable business context that is sent to Gemini on every reply
- introduce a guided scheduling flow that gathers client details and books Google Calendar events via the REST API
- provide environment variables and documentation to configure the WhatsApp advisor experience and calendar integration

## Testing
- npm install *(fails: registry returned 403 for required packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e54ece1fb483219997a820fe5151ca