### PR TITLE
Add typing delay, reactions, and extended Gemini context

### DIFF
--- a/base-baileys-memory/app.js
+++ b/base-baileys-memory/app.js
@@ -28,27 +28,32 @@ const MockAdapter = require('@bot-whatsapp/database/mock')
 const { getGeminiReply } = require('./services/gemini')
 const { contextMessages } = require('./services/context')
 const { handleSchedulingFlow } = require('./services/scheduling')
-const { sendChunkedMessages } = require('./services/message-utils')
+const { sendChunkedMessages, maybeReactToMessage } = require('./services/message-utils')
 const { ensureInitialMenu, handleMenuRequest } = require('./services/menu')
 
-const flowGemini = addKeyword(EVENTS.WELCOME).addAction(async (ctx, { flowDynamic, state }) => {
+const flowGemini = addKeyword(EVENTS.WELCOME).addAction(async (ctx, { flowDynamic, state, provider }) => {
     const message = ctx?.body?.trim()
     if (!message) return
 
     const normalizedMessage = message.toLowerCase()
+
+    await maybeReactToMessage(ctx, provider)
     if (['reset', 'reiniciar', 'limpiar'].includes(normalizedMessage)) {
         await state.clear()
-        await sendChunkedMessages(flowDynamic, '🔄 He reiniciado nuestra conversación. ¿En qué puedo ayudarte ahora?')
+        await sendChunkedMessages(flowDynamic, '🔄 He reiniciado nuestra conversación. ¿En qué puedo ayudarte ahora?', {
+            ctx,
+            provider,
+        })
         return
     }
 
-    await ensureInitialMenu(ctx, { flowDynamic, state })
+    await ensureInitialMenu(ctx, { flowDynamic, state, provider })
 
-    if (await handleMenuRequest(ctx, { flowDynamic, state })) {
+    if (await handleMenuRequest(ctx, { flowDynamic, state, provider })) {
         return
     }
 
-    if (await handleSchedulingFlow(ctx, { flowDynamic, state })) {
+    if (await handleSchedulingFlow(ctx, { flowDynamic, state, provider })) {
         return
     }
 
@@ -57,14 +62,15 @@ const flowGemini = addKeyword(EVENTS.WELCOME).addAction(async (ctx, { flowDynami
         const history = Array.isArray(userState?.geminiHistory) ? userState.geminiHistory : []
         const { reply, history: updatedHistory } = await getGeminiReply(message, history, contextMessages)
         await state.update({ geminiHistory: updatedHistory })
-        await sendChunkedMessages(flowDynamic, reply)
+        await sendChunkedMessages(flowDynamic, reply, { ctx, provider })
     } catch (error) {
         console.error('Gemini API error:', error)
 
         if (error.message === 'GEMINI_API_KEY_MISSING') {
             await sendChunkedMessages(
                 flowDynamic,
-                '⚠️ La clave de la API de Gemini no está configurada. Configura GEMINI_API_KEY en tu entorno y reinicia el bot.'
+                '⚠️ La clave de la API de Gemini no está configurada. Configura GEMINI_API_KEY en tu entorno y reinicia el bot.',
+                { ctx, provider }
             )
             return
         }
@@ -72,23 +78,25 @@ const flowGemini = addKeyword(EVENTS.WELCOME).addAction(async (ctx, { flowDynami
         if (error.message === 'GEMINI_FETCH_FAILED') {
             await sendChunkedMessages(
                 flowDynamic,
-                '⚠️ No pude comunicarme con el servicio de Gemini. Revisa tu conexión a internet y vuelve a intentarlo.'
+                '⚠️ No pude comunicarme con el servicio de Gemini. Revisa tu conexión a internet y vuelve a intentarlo.',
+                { ctx, provider }
             )
             return
         }
 
         if (error.message === 'GEMINI_EMPTY_RESPONSE') {
-            await sendChunkedMessages(
-                flowDynamic,
-                '⚠️ No recibí ninguna respuesta de Gemini. Por favor intenta reformular tu mensaje.'
-            )
+            await sendChunkedMessages(flowDynamic, '⚠️ No recibí ninguna respuesta de Gemini. Por favor intenta reformular tu mensaje.', {
+                ctx,
+                provider,
+            })
             return
         }
 
         if (error.code === 401 || error.code === 403) {
             await sendChunkedMessages(
                 flowDynamic,
-                '⚠️ Gemini rechazó la solicitud. Verifica tu GEMINI_API_KEY y que la cuenta tenga acceso al modelo configurado.'
+                '⚠️ Gemini rechazó la solicitud. Verifica tu GEMINI_API_KEY y que la cuenta tenga acceso al modelo configurado.',
+                { ctx, provider }
             )
             return
         }
@@ -96,20 +104,24 @@ const flowGemini = addKeyword(EVENTS.WELCOME).addAction(async (ctx, { flowDynami
         if (error.code === 429) {
             await sendChunkedMessages(
                 flowDynamic,
-                '⚠️ Se alcanzó el límite de solicitudes de Gemini. Espera unos minutos antes de intentarlo de nuevo.'
+                '⚠️ Se alcanzó el límite de solicitudes de Gemini. Espera unos minutos antes de intentarlo de nuevo.',
+                { ctx, provider }
             )
             return
         }
 
         if (error.message) {
-            await sendChunkedMessages(flowDynamic, `⚠️ Gemini respondió con un error: ${error.message}`)
+            await sendChunkedMessages(flowDynamic, `⚠️ Gemini respondió con un error: ${error.message}`, {
+                ctx,
+                provider,
+            })
             return
         }
 
-        await sendChunkedMessages(
-            flowDynamic,
-            '😔 Ocurrió un error al generar la respuesta. Intenta nuevamente en unos instantes.'
-        )
+        await sendChunkedMessages(flowDynamic, '😔 Ocurrió un error al generar la respuesta. Intenta nuevamente en unos instantes.', {
+            ctx,
+            provider,
+        })
     }
 })
 

--- a/base-baileys-memory/services/gemini.js
+++ b/base-baileys-memory/services/gemini.js
@@ -6,6 +6,8 @@ if (!globalThis.fetch) {
     throw new Error('Fetch API no disponible en este entorno. Actualiza a Node 18 o superior.')
 }
 
+const MAX_HISTORY_ENTRIES = 40
+
 const sanitizeHistory = (history = []) => {
     if (!Array.isArray(history)) return []
 
@@ -18,7 +20,7 @@ const sanitizeHistory = (history = []) => {
                 Array.isArray(entry.parts) &&
                 entry.parts.every((part) => part && typeof part.text === 'string')
         )
-        .slice(-20)
+        .slice(-MAX_HISTORY_ENTRIES)
 }
 
 const buildHistoryEntry = (role, text) => ({
@@ -96,7 +98,7 @@ const getGeminiReply = async (message, history = [], context = []) => {
         ...sanitizedHistory,
         buildHistoryEntry('user', message),
         buildHistoryEntry('model', reply),
-    ].slice(-20)
+    ].slice(-MAX_HISTORY_ENTRIES)
 
     return { reply, history: updatedHistory }
 }

--- a/base-baileys-memory/services/menu.js
+++ b/base-baileys-memory/services/menu.js
@@ -14,47 +14,63 @@ const OPTION_MAPPINGS = [
     },
     {
         keywords: ['2', 'dos', 'requisitos', 'documentos', 'pasos'],
-        handler: async (_ctx, { flowDynamic }) => {
-            await sendChunkedMessages(flowDynamic, [
-                'Estos son los requisitos clave para iniciar la homologación: título o cédula en enfermería y pasaporte vigente.',
-                'También necesitaremos certificados de materias y práctica clínica. Si falta algo, te guiamos para reunirlo paso a paso.',
-            ])
+        handler: async (ctx, { flowDynamic, provider }) => {
+            await sendChunkedMessages(
+                flowDynamic,
+                [
+                    'Estos son los requisitos clave para iniciar la homologación: título o cédula en enfermería y pasaporte vigente.',
+                    'También necesitaremos certificados de materias y práctica clínica. Si falta algo, te guiamos para reunirlo paso a paso.',
+                ],
+                { ctx, provider }
+            )
             return true
         },
     },
     {
         keywords: ['3', 'tres', 'beneficios', 'apoyo'],
-        handler: async (_ctx, { flowDynamic }) => {
-            await sendChunkedMessages(flowDynamic, [
-                'Al homologar con nosotros recibes acompañamiento personalizado, simulacros de examen y asesoría para trámites migratorios.',
-                'Nuestro equipo te prepara para entrevistas laborales y te conecta con aliados en Estados Unidos para acelerar tu contratación.',
-            ])
+        handler: async (ctx, { flowDynamic, provider }) => {
+            await sendChunkedMessages(
+                flowDynamic,
+                [
+                    'Al homologar con nosotros recibes acompañamiento personalizado, simulacros de examen y asesoría para trámites migratorios.',
+                    'Nuestro equipo te prepara para entrevistas laborales y te conecta con aliados en Estados Unidos para acelerar tu contratación.',
+                ],
+                { ctx, provider }
+            )
             return true
         },
     },
     {
         keywords: ['4', 'cuatro', 'costos', 'precio', 'pago', 'financiamiento'],
-        handler: async (_ctx, { flowDynamic }) => {
-            await sendChunkedMessages(flowDynamic, [
-                'El programa cuenta con planes de pago flexibles y opciones de financiamiento. Ajustamos la inversión a tu situación.',
-                'En la llamada de orientación revisamos becas disponibles y promociones activas para que avances con tranquilidad.',
-            ])
+        handler: async (ctx, { flowDynamic, provider }) => {
+            await sendChunkedMessages(
+                flowDynamic,
+                [
+                    'El programa cuenta con planes de pago flexibles y opciones de financiamiento. Ajustamos la inversión a tu situación.',
+                    'En la llamada de orientación revisamos becas disponibles y promociones activas para que avances con tranquilidad.',
+                ],
+                { ctx, provider }
+            )
             return true
         },
     },
     {
         keywords: ['5', 'cinco', 'horarios', 'contacto', 'ubicación'],
-        handler: async (_ctx, { flowDynamic }) => {
-            await sendChunkedMessages(flowDynamic, [
-                `Atendemos de lunes a viernes de 9:00 a 15:00 (hora Ciudad de México).`,
-                `Toda la asesoría es en línea, así que te ayudamos sin importar dónde te encuentres. Escríbenos cuando necesites apoyo.`,
-            ])
+        handler: async (ctx, { flowDynamic, provider }) => {
+            await sendChunkedMessages(
+                flowDynamic,
+                [
+                    `Atendemos de lunes a viernes de 9:00 a 15:00 (hora Ciudad de México).`,
+                    `Toda la asesoría es en línea, así que te ayudamos sin importar dónde te encuentres. Escríbenos cuando necesites apoyo.`,
+                ],
+                { ctx, provider }
+            )
             return true
         },
     },
 ]
 
-const sendMenu = async ({ flowDynamic }, { includeGreeting = false } = {}) => {
+const sendMenu = async ({ flowDynamic, provider }, { ctx, includeGreeting = false } = {}) => {
     const messages = []
 
     if (includeGreeting) {
@@ -65,11 +81,10 @@ const sendMenu = async ({ flowDynamic }, { includeGreeting = false } = {}) => {
     }
 
     messages.push(
-        'Menú principal:\n1️⃣ Agendar cita\n2️⃣ Requisitos y pasos\n3️⃣ Beneficios del programa',
-        '4️⃣ Costos y apoyos\n5️⃣ Horarios y contacto\nEscribe el número o pídeme la opción con tus palabras.'
+        'Menú principal:\n\n1️⃣ Agendar cita\n\n2️⃣ Requisitos y pasos\n\n3️⃣ Beneficios del programa\n\n4️⃣ Costos y apoyos\n\n5️⃣ Horarios y contacto\n\nEscribe el número o pídeme la opción con tus palabras.'
     )
 
-    await sendChunkedMessages(flowDynamic, messages)
+    await sendChunkedMessages(flowDynamic, messages, { ctx, provider })
 }
 
 const ensureInitialMenu = async (ctx, tools) => {
@@ -78,7 +93,7 @@ const ensureInitialMenu = async (ctx, tools) => {
 
     if (myState.hasReceivedMenu) return false
 
-    await sendMenu(tools, { includeGreeting: true })
+    await sendMenu(tools, { ctx, includeGreeting: true })
     await state.update({
         ...myState,
         hasReceivedMenu: true,
@@ -92,7 +107,7 @@ const handleMenuRequest = async (ctx, tools) => {
     if (!message) return false
 
     if (MENU_KEYWORDS.some((keyword) => message.includes(keyword))) {
-        await sendMenu(tools)
+        await sendMenu(tools, { ctx })
         return true
     }
 


### PR DESCRIPTION
## Summary
- add a reusable typing-delay helper that triggers sendStateTyping and enforces a 3s pause before every reply
- refresh the menu and scheduling flows to send messages with the delay metadata and occasionally react to user messages
- expand stored Gemini history to cover the last 20 user turns for richer context

## Testing
- npm run prestart *(fails: ESLint 9 requires migrating to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e5699e74108321877c3dbd7ebcc5b2