### PR TITLE
Streamline Gemini-driven menu guidance and fix typing state error

### DIFF
--- a/base-baileys-memory/app.js
+++ b/base-baileys-memory/app.js
@@ -29,7 +29,6 @@ const { getGeminiReply } = require('./services/gemini')
 const { contextMessages } = require('./services/context')
 const { handleSchedulingFlow } = require('./services/scheduling')
 const { sendChunkedMessages } = require('./services/message-utils')
-const { ensureInitialMenu, handleMenuRequest } = require('./services/menu')
 const { maybeReactToMessage } = require('./services/reactions')
 
 const flowGemini = addKeyword(EVENTS.WELCOME).addAction(async (ctx, { flowDynamic, state, provider }) => {
@@ -46,12 +45,6 @@ const flowGemini = addKeyword(EVENTS.WELCOME).addAction(async (ctx, { flowDynami
             '🔄 He reiniciado nuestra conversación. ¿En qué puedo ayudarte ahora?',
             { ctx, provider }
         )
-        return
-    }
-
-    await ensureInitialMenu(ctx, { flowDynamic, state, provider })
-
-    if (await handleMenuRequest(ctx, { flowDynamic, state, provider })) {
         return
     }
 

--- a/base-baileys-memory/services/context.js
+++ b/base-baileys-memory/services/context.js
@@ -1,3 +1,5 @@
+const { buildMenuGuidance } = require('./menu')
+
 const businessInfo = {
     organizationName: 'Consejo de Enfermería',
     description:
@@ -25,19 +27,18 @@ const buildOptionalSections = () => {
     return optionalLines.join('\n')
 }
 
-const baseContext = `Eres el asistente virtual oficial de ${businessInfo.organizationName} en WhatsApp. ${businessInfo.description}
+const contextSections = [
+    `Eres el asistente virtual oficial de ${businessInfo.organizationName} en WhatsApp. ${businessInfo.description}`,
+    'Tu objetivo es escuchar atentamente la situación de la persona, explicar de forma clara el proceso de homologación y recalcar que contará con un asesor que la guiará paso a paso hasta obtener la validación en Estados Unidos.',
+    'Proporciona información práctica y confiable basada en los datos disponibles. Si falta algún detalle (como horarios exactos, direcciones o precios), aclara que un asesor lo confirmará durante la llamada de orientación.',
+    'Mantén un tono cálido, profesional y motivador. Resume los pasos principales del proceso y resalta los beneficios de contar con nuestro acompañamiento personalizado.',
+    `Siempre invita a agendar una llamada de orientación. Indica que pueden escribir alguna de las siguientes frases para iniciar la reserva automática: ${businessInfo.schedulingKeywords.join(', ')}.`,
+    'Comparte la información en bloques breves de máximo cuatro líneas. Si el tema es extenso, divídelo en varios mensajes y confirma si la persona necesita más detalles antes de continuar.',
+    buildOptionalSections(),
+    buildMenuGuidance(businessInfo.organizationName),
+].filter(Boolean)
 
-Tu objetivo es escuchar atentamente la situación de la persona, explicar de forma clara el proceso de homologación y recalcar que contará con un asesor que la guiará paso a paso hasta obtener la validación en Estados Unidos.
-
-Proporciona información práctica y confiable basada en los datos disponibles. Si falta algún detalle (como horarios exactos, direcciones o precios), aclara que un asesor lo confirmará durante la llamada de orientación.
-
-Mantén un tono cálido, profesional y motivador. Resume los pasos principales del proceso y resalta los beneficios de contar con nuestro acompañamiento personalizado.
-
-Siempre invita a agendar una llamada de orientación. Indica que pueden escribir alguna de las siguientes frases para iniciar la reserva automática: ${businessInfo.schedulingKeywords.join(', ')}.
-
-Comparte la información en bloques breves de máximo cuatro líneas. Si el tema es extenso, divídelo en varios mensajes y confirma si la persona necesita más detalles antes de continuar.
-
-${buildOptionalSections()}`.trim()
+const baseContext = contextSections.join('\n\n')
 
 const contextMessages = [
     {


### PR DESCRIPTION
## Summary
- remove the legacy menu interceptors so Gemini owns the full conversational flow
- refresh the assistant context with guidance to show a concise menu and keep responses short
- simplify menu utilities to provide guidance data for Gemini and harden typing simulation with safer presence handling

## Testing
- npm run prestart *(fails: ESLint 9 requires eslint.config.js in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68e57cf8e1b08321a46def790952792c